### PR TITLE
fix: make test and skip methods available

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ module.exports = {
 		const mapped = map(path, 'qunit2-parameterize.js', (content) => {
 			const newContent = [
 				";define('qunit-parameterize', ['exports', 'ember-qunit'], function(exports, emberQunit) {\n",
-				'var QUnit = window.QUnit; emberQunit.extend = QUnit.extend; QUnit = emberQunit;\n',
+				'var QUnit = window.QUnit;\n',
+				'emberQunit.extend = QUnit.extend; emberQunit.skip = QUnit.skip; emberQunit.test = QUnit.test;\n',
+				'QUnit = emberQunit;\n',
 				content,
 				"exports['default'] = QUnit.cases.init.bind(QUnit.cases);\n});"
 			];


### PR DESCRIPTION
Following https://github.com/emberjs/ember-qunit/pull/737/files they are not exported anymore by ember-qunit, making this package not working anymore with `ember-qunit` >5.0.0

As for the `QUnit` `extend` method, we also copy the `skip` and `test` methods

See https://github.com/BBVAEngineering/ember-cli-qunit-parameterize/issues/5